### PR TITLE
Call ffprobe via child_process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,15 @@
 language: node_js
+
 node_js:
-  - '10'
+  - "10"
 
 script:
   - npm run lint
   - npm run test
+
+before_install:
+  - sudo apt-get install -y --no-install-recommends ffmpeg
+
+addons:
+  apt:
+    update: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "iptv-checker",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1852,9 +1852,9 @@
       }
     },
     "iptv-playlist-parser": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/iptv-playlist-parser/-/iptv-playlist-parser-0.4.0.tgz",
-      "integrity": "sha512-zgNM3chjwgd3bBQsujhdbospyYHky/zURdRSx5uVSkWK5Md6YssrIrVp98WMjJVx5dTlP81C8bdbPGYEyEIfOA=="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/iptv-playlist-parser/-/iptv-playlist-parser-0.4.1.tgz",
+      "integrity": "sha512-Nx+peCwP9B964Bdv7samCC42so8ATam4qE/RI6Ifs5mzvfbOevPv061ZmdSCr6GmZdWXCIV/fpzJfcWO8FrYyQ=="
     },
     "irregular-plurals": {
       "version": "3.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "iptv-checker",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -380,11 +380,6 @@
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
-    },
-    "async": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.1.0.tgz",
-      "integrity": "sha512-4vx/aaY6j/j3Lw3fbCHNWP0pPaTCew3F6F3hYyl/tHs/ndmV1q7NW9T5yuJ2XAGwdQrP+6Wu20x06U4APo/iQQ=="
     },
     "ava": {
       "version": "3.6.0",
@@ -1537,15 +1532,6 @@
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
     },
-    "fluent-ffmpeg": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/fluent-ffmpeg/-/fluent-ffmpeg-2.1.2.tgz",
-      "integrity": "sha1-yVLeIkD4EuvaCqgAbXd27irPfXQ=",
-      "requires": {
-        "async": ">=0.2.9",
-        "which": "^1.1.1"
-      }
-    },
     "follow-redirects": {
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
@@ -2003,7 +1989,8 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
     },
     "isobject": {
       "version": "4.0.0",
@@ -3406,6 +3393,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "iptv-checker",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -903,6 +903,11 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+    },
+    "command-exists": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.8.tgz",
+      "integrity": "sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw=="
     },
     "commander": {
       "version": "2.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iptv-checker",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Node.js CLI tool for checking links in IPTV playlists",
   "main": "src/index.js",
   "preferGlobal": true,
@@ -30,6 +30,7 @@
   "dependencies": {
     "axios": "^0.19.2",
     "colors": "^1.4.0",
+    "command-exists": "^1.2.8",
     "commander": "^2.20.0",
     "dateformat": "^3.0.3",
     "get-stdin": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "colors": "^1.4.0",
     "commander": "^2.20.0",
     "dateformat": "^3.0.3",
-    "fluent-ffmpeg": "^2.1.2",
     "get-stdin": "^7.0.0",
     "iptv-playlist-parser": "^0.4.0",
     "progress": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "commander": "^2.20.0",
     "dateformat": "^3.0.3",
     "get-stdin": "^7.0.0",
-    "iptv-playlist-parser": "^0.4.0",
+    "iptv-playlist-parser": "^0.4.1",
     "progress": "^2.0.3",
     "valid-url": "^1.0.9"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iptv-checker",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Node.js CLI tool for checking links in IPTV playlists",
   "main": "src/index.js",
   "preferGlobal": true,

--- a/src/helper.js
+++ b/src/helper.js
@@ -108,7 +108,7 @@ function ffprobe(item, { userAgent, timeout }) {
 
     addToCache(url)
 
-    const cmd = `ffprobe -of json -v error -hide_banner -show_format -show_streams -user_agent "${userAgent}" ${url}`
+    const cmd = `ffprobe -of json -v error -hide_banner -show_format -show_streams -user_agent "${userAgent}" '${url}'`
 
     exec(cmd, { timeout }, err => {
       if (err) {

--- a/src/helper.js
+++ b/src/helper.js
@@ -5,14 +5,6 @@ const urlParser = require('url')
 const getStdin = require('get-stdin')
 const { isWebUri } = require('valid-url')
 const { exec } = require('child_process')
-const commandExists = require('command-exists')
-
-commandExists(`ffprobe`).catch(() => {
-  console.error(
-    `Executable "ffprobe" not found. Have you installed "ffmpeg"?`.red
-  )
-  process.exit(1)
-})
 
 let cache = new Set()
 

--- a/src/helper.js
+++ b/src/helper.js
@@ -75,7 +75,7 @@ function writeToFile(path, item, message = null) {
   const extinf = lines[0]
 
   if (message) {
-    lines[0] = extinf + ` (${message})`
+    lines[0] = `${extinf} (${message})`
   }
 
   fs.appendFileSync(path, `${lines.join('\n')}\n`)
@@ -94,14 +94,6 @@ const debugLogger = (dbg = false) => {
   return (...args) => console.log(...args)
 }
 
-function isJSON(str) {
-  try {
-    return !!JSON.parse(str)
-  } catch (e) {
-    return false
-  }
-}
-
 function ffprobe(item, { userAgent, timeout }) {
   return new Promise(resolve => {
     const { url } = item
@@ -118,7 +110,7 @@ function ffprobe(item, { userAgent, timeout }) {
 
     const cmd = `ffprobe -of json -v error -hide_banner -show_format -show_streams -user_agent "${userAgent}" ${url}`
 
-    exec(cmd, { timeout }, (err, stdout) => {
+    exec(cmd, { timeout }, err => {
       if (err) {
         resolve({ status: status.FAILED, message: parseError(err.message) })
       }

--- a/src/helper.js
+++ b/src/helper.js
@@ -5,6 +5,14 @@ const urlParser = require('url')
 const getStdin = require('get-stdin')
 const { isWebUri } = require('valid-url')
 const { exec } = require('child_process')
+const commandExists = require('command-exists')
+
+commandExists(`ffprobe`).catch(() => {
+  console.error(
+    `Executable "ffprobe" not found. Have you installed "ffmpeg"?`.red
+  )
+  process.exit(1)
+})
 
 let cache = new Set()
 

--- a/src/helper.js
+++ b/src/helper.js
@@ -51,7 +51,20 @@ async function parsePlaylist(fileOrUrl = ``) {
   }
   const result = parser.parse(content)
 
-  result.items = result.items.filter(i => isWebUri(i.url))
+  result.duplicates = []
+
+  result.items = result.items
+    .filter(i => isWebUri(i.url))
+    .map(i => {
+      if (checkCache(i.url)) {
+        result.duplicates.push(i)
+        return null
+      } else {
+        addToCache(i.url)
+        return i
+      }
+    })
+    .filter(Boolean)
 
   return result
 }

--- a/src/helper.js
+++ b/src/helper.js
@@ -55,28 +55,7 @@ async function parsePlaylist(fileOrUrl = ``) {
     content = readFile(fileOrUrl)
   }
 
-  const playlist = parser.parse(content)
-
-  return filterDuplicates(playlist)
-}
-
-function filterDuplicates(playlist) {
-  playlist.duplicates = []
-  const { items } = playlist
-
-  for (let i = 0; i < items.length; i++) {
-    let { url } = items[i]
-    if (checkCache(url)) {
-      playlist.duplicates.push({ ...items[i] })
-      items[i] = null // preserve the index
-      continue
-    }
-    addToCache(url)
-  }
-
-  playlist.items = playlist.items.filter(Boolean) // remove nulled items
-
-  return playlist
+  return parser.parse(content)
 }
 
 function addToCache(url) {
@@ -122,6 +101,12 @@ function ffprobe(item, { userAgent, timeout }) {
     if (!isWebUri(url)) {
       resolve({ status: status.FAILED, message: `Invalid URL` })
     }
+
+    if (checkCache(url)) {
+      resolve({ status: status.DUPLICATE })
+    }
+
+    addToCache(url)
 
     const cmd = `ffprobe -of json -v error -hide_banner -show_format -show_streams -user_agent "${userAgent}" '${url}'`
 

--- a/src/index.js
+++ b/src/index.js
@@ -91,11 +91,11 @@ async function init() {
     bar = new ProgressBar(':bar', { total: stats.total })
 
     for (let item of playlist.items) {
+      await validate(item)
+
       if (!config.debug) {
         bar.tick()
       }
-
-      await validate(item)
     }
 
     if (config.debug) {

--- a/src/index.js
+++ b/src/index.js
@@ -84,26 +84,13 @@ async function init() {
 
     let playlist = await helper.parsePlaylist(seedFile)
 
-    const { items, duplicates } = playlist
-
-    stats.total = items.length + duplicates.length
-    stats.duplicates = duplicates.length
+    stats.total = playlist.items.length
 
     debugLogger(`Checking ${stats.total} items...`)
 
     bar = new ProgressBar(':bar', { total: stats.total })
 
-    for (let duplicate of duplicates) {
-      debugLogger(`${duplicate.url} (Duplicate)`.yellow)
-
-      helper.writeToFile(duplicatesFile, duplicate)
-
-      if (!config.debug) {
-        bar.tick()
-      }
-    }
-
-    for (let item of items) {
+    for (let item of playlist.items) {
       await validate(item)
 
       if (!config.debug) {
@@ -140,7 +127,13 @@ async function validate(item) {
     debugLogger(`${item.url}`.green)
 
     stats.online++
-  } else {
+  } else if (result.status === helper.status.DUPLICATE) {
+    helper.writeToFile(duplicatesFile, item)
+
+    debugLogger(`${item.url} (Duplicate)`.yellow)
+
+    stats.duplicates++
+  } else if (result.status === helper.status.FAILED) {
     helper.writeToFile(offlineFile, item, result.message)
 
     debugLogger(`${item.url} (${result.message})`.red)

--- a/src/index.js
+++ b/src/index.js
@@ -133,4 +133,8 @@ async function validateStatus(item) {
 
     stats.offline++
   }
+
+  if (!config.debug) {
+    bar.tick()
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,16 @@ const argv = require('commander')
 const ProgressBar = require('progress')
 const dateFormat = require('dateformat')
 const { version } = require('../package.json')
+const commandExists = require('command-exists')
+
 let seedFile
+
+commandExists(`ffprobe`).catch(() => {
+  console.error(
+    `Executable "ffprobe" not found. Have you installed "ffmpeg"?`.red
+  )
+  process.exit(1)
+})
 
 argv
   .version(version, '-v, --version')

--- a/src/index.js
+++ b/src/index.js
@@ -75,27 +75,23 @@ async function init() {
 
     let playlist = await helper.parsePlaylist(seedFile)
 
-    stats.total = playlist.items.length
+    stats.total = playlist.items.length + playlist.duplicates.length
 
-    debugLogger(`Checking ${stats.total} items...`.yellow)
+    stats.duplicates = playlist.duplicates.length
+
+    debugLogger(`Checking ${stats.total} items...`)
+    debugLogger(`Found ${stats.duplicates} duplicates...`.yellow)
 
     bar = new ProgressBar(':bar', { total: stats.total })
 
-    for (let item of playlist.items) {
+    for (let item of playlist.duplicates) {
       if (!config.debug) {
         bar.tick()
       }
+      helper.writeToFile(duplicatesFile, item)
+    }
 
-      if (helper.checkCache(item.url)) {
-        helper.writeToFile(duplicatesFile, item)
-
-        stats.duplicates++
-
-        continue
-      }
-
-      helper.addToCache(item.url)
-
+    for (let item of playlist.items) {
       await validateStatus(item)
     }
 

--- a/test/input/dummy.m3u
+++ b/test/input/dummy.m3u
@@ -4,14 +4,15 @@
 #EXTINF:0 group-title="(US) United States",offline
 https://autoiptv.net
 
+#EXTINF:-1,online [not 24/7]
+https://streaming-live.rtp.pt/livetvhlsDVR/rtpndvr.smil/playlist.m3u8
+
 
 #EXTINF:-1,invalid
 in:valid/30515.hlsplay.aodianyun.com/lms_30515/tv_channel_239.m3u8
 
 
 
-#EXTINF:-1,online [not 24/7]
-https://streaming-live.rtp.pt/livetvhlsDVR/rtpndvr.smil/playlist.m3u8
 #EXTINF:-1,online [not 24/7]
 #EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64)
 https://streaming-live.rtp.pt/liverepeater/smil:rtpi.smil/playlist.m3u8

--- a/test/input/dummy.m3u
+++ b/test/input/dummy.m3u
@@ -1,6 +1,15 @@
 
 #EXTM3U x-tvg-url="http://195.154.221.171/epg/guidealbania.xml.gz"
 
+#EXTINF:0 group-title="(US) United States",offline
+https://autoiptv.net
+
+
+#EXTINF:-1,invalid
+in:valid/30515.hlsplay.aodianyun.com/lms_30515/tv_channel_239.m3u8
+
+
+
 #EXTINF:-1,online [not 24/7]
 https://streaming-live.rtp.pt/livetvhlsDVR/rtpndvr.smil/playlist.m3u8
 #EXTINF:-1,online [not 24/7]
@@ -9,7 +18,7 @@ https://streaming-live.rtp.pt/liverepeater/smil:rtpi.smil/playlist.m3u8
 
 #EXTINF:-1,online
 http://161.0.157.9/PLTV/88888888/224/3221226834/03.m3u8
-#EXTINF:-1,duplicate
+#EXTINF:-1,online
 http://161.0.157.9/PLTV/88888888/224/3221226834/index.m3u8
 #EXTINF:-1 tvg-logo="" group-title="libya ",online
 https://content.uplynk.com/channel/4ee18bd581dc4d3b90303e0cb9beeb0f.m3u8
@@ -20,16 +29,7 @@ https://content.uplynk.com/channel/4ee18bd581dc4d3b90303e0cb9beeb0f.m3u8
 http://c13-ply.janus.cl/playlist/stream.m3u8?s=c13hd
 
 
-=========================sudan===================================
-#EXTINF:-1,online
-http://30515.hlsplay.aodianyun.com/lms_30515/tv_channel_239.m3u8
 
-
-#EXTM3U
-
-
-#EXTINF:0 group-title="(US) United States",offline
-https://autoiptv.net
 #EXTINF:123 tvg-name="" tvg-id="" tvg-logo="https://i.imgur.com/pGGBPBs.png",online
 http://albuk.dyndns.tv:1935/albuk/albuk.stream/playlist.m3u8
 #EXTINF:-1,timeout


### PR DESCRIPTION
This PR addresses #8 by calling `ffprobe` directly via Node's native `child_process` API (rather than relying on `fluent-ffmpeg`'s flawed `.ffprobe` API).

In other words: it makes `timeout` a usable config option, as right now it is ignored despite being (IMO) one of the most significant parameters for this tool.

## Major Changes

- **Respecting timeout**: Node's `child_process.exec` accepts a timeout option, and will automatically kill the spawned `ffprobe`-calling process if said timeout is exceeded.

- **Duplicate Handling**:  Duplicates are identified upon playlist parsing and processed before item checking. 

## Minor Changes

- **Dependencies**: `fluent-ffmpeg` is no longer a dependency.

- **Debug Logging**: Clearer debug output for passing and failing items.

## Notes
This also paves the way for concurrent channel checking, which will be added in a future PR 👍