### PR TITLE
Bugfix: Update iptv-checker-module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1857,15 +1857,15 @@
       }
     },
     "iptv-checker-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/iptv-checker-module/-/iptv-checker-module-2.0.0.tgz",
-      "integrity": "sha512-tfL0a4zfseRQ53HPzbhSYyarsP7aErCylW29upEGpWXeZye5d5A6cOd8oMhKcXt0DVUrwWUoHyCLnjgkqFyigQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/iptv-checker-module/-/iptv-checker-module-2.0.1.tgz",
+      "integrity": "sha512-ppVyhXm4kfdmVAyMVWC3DkhS2D3/LZCy1SFTw0/VRCXjNszINxXFS07sNjYKSOEtKUWDd94E9zIgaCZfPeA0+w==",
       "requires": {
         "axios": "^0.19.2",
         "colors": "^1.4.0",
         "command-exists": "^1.2.9",
         "iptv-playlist-parser": "^0.4.3",
-        "nanoid": "^3.1.9",
+        "nanoid": "^3.1.10",
         "valid-url": "^1.0.9"
       }
     },
@@ -2279,9 +2279,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.9.tgz",
-      "integrity": "sha512-fFiXlFo4Wkuei3i6w9SQI6yuzGRTGi8Z2zZKZpUxv/bQlBi4jtbVPBSNFZHQA9PNjofWqtIa8p+pnsc0kgZrhQ=="
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.10.tgz",
+      "integrity": "sha512-iZFMXKeXWkxzlfmMfM91gw7YhN2sdJtixY+eZh9V6QWJWTOiurhpKhBMgr82pfzgSqglQgqYSCowEYsz8D++6w=="
     },
     "natural-compare": {
       "version": "1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "iptv-checker",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iptv-checker",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Node.js CLI tool for checking links in IPTV playlists",
   "main": "src/index.js",
   "preferGlobal": true,

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "commander": "^2.20.0",
     "dateformat": "^3.0.3",
     "get-stdin": "^7.0.0",
-    "iptv-checker-module": "^2.0.0",
+    "iptv-checker-module": "^2.0.1",
     "progress": "^2.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Turns out there's a [stupid variety of acceptable MIME types](https://en.wikipedia.org/wiki/M3U#Internet_media_types) for .m3u files, but the module was accepting only `audio/x-mpegurl` when fetching playlist URLs.

The module was updated to fix the bug, and this PR bumps this package to the fixed checker-module version  (v2.0.1)