### PR TITLE
#24 works on Windows, but still shows undefined

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -137,18 +137,18 @@ function buildCommand(item, config) {
   ]
 
   if (config.timeout) {
-    args.push(`-timeout`, `'${config.timeout * 1000}'`)
+    args.push(`-timeout`, `"${config.timeout * 1000}"`)
   }
 
   if (item.http.referrer) {
-    args.push(`-headers`, `'Referer: ${item.http.referrer}'`)
+    args.push(`-headers`, `"Referer: ${item.http.referrer}"`)
   }
 
   if (userAgent) {
-    args.push(`-user_agent`, `'${userAgent}'`)
+    args.push(`-user_agent`, `"${userAgent}"`)
   }
 
-  args.push(`'${item.url}'`)
+  args.push(`"${item.url}"`)
 
   args = args.join(` `)
 


### PR DESCRIPTION
For #24 issue, now ffmpeg works on both (windows or wsl2 linux) systems, yet shows undefined sometimes, also on both systems, maybe it something connected with Logger or some exceptions, not sure:
On WSL2 Ubuntu 20.04 LTS: https://i.imgur.com/T5kN1lW.png - here the second start with -p 120 gone all wrong with zero online results, and third start with -p 60 returned normal online.m3u with 45550 bytes in it. So it looks like program tries to communicate, but something goes wrong.
On Windows: https://i.imgur.com/JQfEW4C.png but on some dummy.m3u it goes ok: https://i.imgur.com/7RK0SgX.png

So, about windows specific thingy: looks like problem in single quotes in cmd args builder on Windows OS, as proposed by https://github.com/freearhey/iptv-checker/issues/24#issuecomment-1006772513
changed some single quotes to double quotes in helper.js, with difference in line 144 args.push(`-headers`, `"Referer: ${item.http.referrer}"`)     - included in quotes also Referer, so test command like 

ffprobe -of json -hide_banner -timeout "60000000" -headers "Referer: www.google.com" "https://live-hls-web-aje.getaj.net/AJE/index.m3u8"
works fine on Windows, **yet it complaining with warning about** "[https @ 000001e5c93f3ec0] No trailing CRLF found in HTTP header. Adding it.", here https://stackoverflow.com/questions/33718810/ffmpeg-how-to-pass-http-headers best answer suggests to use -user-agent and ensure, that ffmpeg updated, so it added it automatically.