### PR TITLE
add wait between checks

### DIFF
--- a/bin/iptv-checker.js
+++ b/bin/iptv-checker.js
@@ -30,6 +30,11 @@ argv
     60000
   )
   .option(
+    '-w, --wait <timeout>',
+    'Set the number of milliseconds before next stream checked',
+    1000
+  )
+  .option(
     '-p, --parallel <number>',
     'Batch size of items to check concurrently',
     1
@@ -54,6 +59,7 @@ const config = {
   userAgent: argv.userAgent,
   timeout: parseInt(argv.timeout),
   parallel: +argv.parallel,
+  wait: argv.wait,
   setUp,
   afterEach,
 }

--- a/src/index.js
+++ b/src/index.js
@@ -105,10 +105,19 @@ class IPTVChecker {
     } else {
       logger.debug(`FAILED: ${item.url} (${item.status.message})`.red)
     }
-
+    logger.debug(`waiting ${config.wait} milliseconds`);
     await config.afterEach(item)
-
+    await this.Wait();
     return item
+  }
+
+  Wait() {
+    const { config } = this
+    return new Promise((resolve, reject) => {
+        setTimeout(()=> {
+            resolve();
+        },config.wait)
+    })
   }
 }
 


### PR DESCRIPTION
As user stated some providers/cloudflare will give error code 429 for too many requests. Especially happens when there are 404 not found on many streams.