### PR TITLE
[VIBECODE ALERT] Suppressing for Skip #EXT-X-lines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iptv-checker",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "iptv-checker",
-      "version": "0.30.0",
+      "version": "0.31.0",
       "license": "MIT",
       "dependencies": {
         "async": "^3.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iptv-checker",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "Node.js CLI tool for checking links in IPTV playlists",
   "main": "src/index.js",
   "type": "module",

--- a/src/core/FFprobe.js
+++ b/src/core/FFprobe.js
@@ -2,11 +2,8 @@ import { FFprobeCommandBuilder } from './FFprobeCommandBuilder.js'
 import { FFprobeOutputParser } from './FFprobeOutputParser.js'
 import { FFprobeErrorParser } from './FFprobeErrorParser.js'
 import { TESTING } from '../constants.js'
-import { exec } from 'child_process'
+import { spawn } from 'child_process'
 import errors from '../errors.js'
-import util from 'util'
-
-const execAsync = util.promisify(exec)
 
 export class FFprobe {
   constructor({ config, logger }) {
@@ -31,7 +28,7 @@ export class FFprobe {
         const ffprobeOutput = (await import('../../tests/__mocks__/ffprobe.js')).default
         output = ffprobeOutput[item.url]
       } else {
-        output = await execAsync(command, { timeout })
+        output = await spawnFiltered(command, timeout)
       }
 
       this.logger.debug(output)
@@ -72,6 +69,47 @@ export class FFprobe {
       }
     }
   }
+}
+
+function spawnFiltered(command, timeout) {
+  return new Promise((resolve, reject) => {
+    const [cmd, ...args] = command.match(/(?:[^\s"]+|"[^"]*")+/g)
+    const proc = spawn(cmd, args.map(a => a.replace(/^"|"$/g, '')))
+
+    let stdout = ''
+    let stderr = ''
+    let killed = false
+
+    const timer = timeout ? setTimeout(() => {
+      killed = true
+      proc.kill()
+      reject(Object.assign(new Error('process timeout'), { stdout, stderr }))
+    }, timeout) : null
+
+    proc.stdout.on('data', chunk => { stdout += chunk })
+    proc.stderr.on('data', chunk => {
+      const filtered = chunk.toString()
+        .split('\n')
+        .filter(line => !line.includes("Skip ('#EXT-X-"))
+        .join('\n')
+      stderr += filtered
+    })
+
+    proc.on('close', code => {
+      if (killed) return
+      if (timer) clearTimeout(timer)
+      if (code !== 0) {
+        reject(Object.assign(new Error(`ffprobe exited with code ${code}`), { stdout, stderr }))
+      } else {
+        resolve({ stdout, stderr })
+      }
+    })
+
+    proc.on('error', err => {
+      if (timer) clearTimeout(timer)
+      reject(Object.assign(err, { stdout, stderr }))
+    })
+  })
 }
 
 function isJSON(str) {


### PR DESCRIPTION
Spawns the ffprobe process manually, allowing to filter stderr lines on the fly before they accumulate, specifically Skip #EXT-X-lines. Prevents buffer overflow and allows to eliminate some false positives. Tested against https://livetv.mylifeisgood.net.ru/channels/terra.m3u8 and https://2vko9pchwon.a.trbcdn.net/livemaster/8ilgc_cw63ucn03p.smil/playlist.m3u8. May cause unexpected regressions, needs to be tested further

Automated test result
``` 
 PASS  tests/index.test.js
(node:9224) Warning: `--localstorage-file` was provided without a valid path
(Use `node --trace-warnings ...` to show where the warning was created)

(node:2028) Warning: `--localstorage-file` was provided without a valid path
(Use `node --trace-warnings ...` to show where the warning was created)

(node:10856) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
 PASS  tests/bin.test.js

Test Suites: 2 passed, 2 total
Tests:       16 passed, 16 total
Snapshots:   0 total
Time:        2.115 s
Ran all test suites.
```